### PR TITLE
#1 Fixed brand and name

### DIFF
--- a/adapters/autohero.go
+++ b/adapters/autohero.go
@@ -133,7 +133,7 @@ func getBrandModel(link string)(string,[]string){
 
 	if len(sarr)<6{return "",nil}
 
-	bm := strings.Split(sarr[5],"-")
+	bm := strings.Split(sarr[4],"-")
 
 	bi := 0
 


### PR DESCRIPTION
When link has been fixed (contained 1 too many '/' brand extraction was a victim
Fixed